### PR TITLE
Fix `Encoding.default_internal` in backend (ASC-46)

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -18,3 +18,14 @@ module ActiveSupport
     end
   end
 end
+
+# Correct default internal encoding to ensure PDF generation works as expected.
+# This is necessary because Rails (which is needed by the plugin) changes the default internal
+# encoding to UTF-8, which causes an UndefinedConversionError when writing PDFs.
+# Setting it to nil restores the setting to the state it was in before the plugin is loaded.
+
+# Resources
+# - https://github.com/rails/rails/blob/8030cff808657faa44828de001cd3b80364597de/railties/lib/rails.rb#L20-L24
+# - https://ruby-doc.org/2.7.8/Encoding.html#method-c-default_internal
+
+Encoding.default_internal = nil

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # RSpec tests for mlibrary/aspace-oauth
 
-This project has a basic setup for running unit tests.\
+This project has a basic setup for running unit tests.
 It should be sufficient for writing and testing aspects of the code which do not rely on ArchivesSpace directly.
 
 ## Building and running tests

--- a/spec/backend_plugin_init_spec.rb
+++ b/spec/backend_plugin_init_spec.rb
@@ -11,5 +11,15 @@ RSpec.describe do
       test_hash = {test_date: Date}
       expect(test_hash.to_json).to eq('{"test_date":"Date"}')
     end
+
+    # Simulating what Rails 5 does
+    Encoding.default_internal = 'UTF-8'
+
+    # Force re-load after re-settiung
+    load("./backend/plugin_init.rb")
+
+    it "resets the default internal encoding from UTF-8 to nil" do
+      expect(Encoding.default_internal).to eq(nil)
+    end
   end
 end

--- a/spec/backend_plugin_init_spec.rb
+++ b/spec/backend_plugin_init_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe do
     # Simulating what Rails 5 does
     Encoding.default_internal = 'UTF-8'
 
-    # Force re-load after re-settiung
+    # Force re-load after re-setting
     load("./backend/plugin_init.rb")
 
     it "resets the default internal encoding from UTF-8 to nil" do


### PR DESCRIPTION
This PR aims to resolve [ASC-46](https://mlit.atlassian.net/jira/software/projects/ASC/boards/88?selectedIssue=ASC-46).